### PR TITLE
Fix audio initialization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -97,7 +97,9 @@ export default function App() {
 
   const initializeAudio = () => {
     if (!audioContextRef.current) {
-        audioContextRef.current = new (window.AudioContext || window.webkitAudioContext?.bind(window))();
+        const AudioCtx = window.AudioContext || window.webkitAudioContext;
+        if (!AudioCtx) return;
+        audioContextRef.current = new AudioCtx();
     }
     setSoundEnabled(true);
     playSound('click');


### PR DESCRIPTION
## Summary
- handle Safari AudioContext without optional chaining

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6844408caae08332971b2e8a4e0b6897